### PR TITLE
Update mod identifier for Deep Woods compatibility

### DIFF
--- a/Stardew Valley Expanded/[CP] Stardew Valley Expanded/code/Locations/MapPatches.json
+++ b/Stardew Valley Expanded/[CP] Stardew Valley Expanded/code/Locations/MapPatches.json
@@ -586,7 +586,7 @@
             "Target": "Maps/Woods",
             "FromFile": "Assets/Maps/MapPatches/DeepWoodsCompatibility.tmx",
             "When": {
-                "HasMod": "maxvollmer.deepwoodsmod"
+                "HasMod": "maxmakesmods.deepwoodsmod"
             },
             "ToArea": {
                 "X": 23,


### PR DESCRIPTION
I saw some talk about this fix when looking at the DeepWoods mod. When I came over here, I saw that it wasn't yet implemented. Just making sure it doesn't get lost. Thanks!